### PR TITLE
Show posts from only one day when using single date argument

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,8 +30,8 @@ By default, the script will find new posts in the `Server` category that were cr
 Dates must follow the format: `%Y-%m-%d` (e.g. 2019-12-17, 2020-05-26)
 
 #### Single Date Argument
-If only one date is given then posts from the start of that day up until today will be found. 
-For example, the following finds all posts in the `Server` category from April 27th, 2022 to today:
+If one date is given then posts from only that day will be found. 
+For example, the following finds all posts in the `Server` category from April 27th, 2022:
 
     dsctriage 2022-04-27
 

--- a/dsctriage/dsctriage.py
+++ b/dsctriage/dsctriage.py
@@ -113,7 +113,7 @@ def parse_dates(start=None, end=None):
             raise ValueError(f"Cannot parse date: {start}") from error
 
     if end is None:
-        end = yesterday.strftime('%Y-%m-%d')
+        end = start
     elif not re.fullmatch(r'\d{4}-\d{2}-\d{2}', end):
         raise ValueError(f"Cannot parse end date: {str(end)}")
 


### PR DESCRIPTION
When using a single date argument, report back with posts only from that day rather than from then to yesterday. Closes #3 