### PR TITLE
Allow users to triage non-Ubuntu Discourse Servers

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,9 +3,10 @@
 [![CI](https://github.com/lvoytek/discourse-triage/actions/workflows/main.yml/badge.svg)](https://github.com/lvoytek/discourse-triage/actions/workflows/main.yml)
 [![dsctriage](https://snapcraft.io/dsctriage/badge.svg)](https://snapcraft.io/dsctriage)
 
-Output comments from [Ubuntu Discourse](https://discourse.ubuntu.com) for triage. This script is used by the Ubuntu
-Server team to keep up with suggested fixes and issues in the [Ubuntu Server Guide](https://ubuntu.com/server/docs). It
-can, however, also be used to look into Discourse posts in other sections of Ubuntu's documentation.
+Output comments from a [Discourse](https://www.discourse.org/) server for triage. This script is used by the Ubuntu
+Server team to keep up with suggested fixes and issues in the [Ubuntu Server Guide](https://ubuntu.com/server/docs), 
+using [Ubuntu's Discourse site](https://discourse.ubuntu.com). It can, however, also be used to look into Discourse 
+posts on any Discourse server, or other sections of Ubuntu's documentation.
 
 The easiest way to install and keep dsctriage up to date is through snap:
 
@@ -50,8 +51,18 @@ Running triage for Monday will show comments from last Friday and the weekend:
 
     dsctriage mon
 
+### Server
+To use a different Discourse server/website, use the `-s` or `--site` option, along with the desired base URL. For example,
+to get yesterday's posts in the `plugin` category of [Discourse's meta site](https://meta.discourse.org/), run:
+
+    dsctriage -s https://meta.discourse.org -c plugin
+
+or:
+
+    dsctriage --site https://meta.discourse.org -c plugin
+
 ### Category
-If you want to find comments in a different category (see the [category list](https://discourse.ubuntu.com/categories)),
+If you want to find comments in a different category (see the [Ubuntu category list](https://discourse.ubuntu.com/categories)),
 then you can specify it with the `-c` or `--category` option. Discourse Triage will attempt to match the name with an
 existing category, case-insensitive. For example, to get comments from yesterday or over the weekend in the `Desktop` category, run
 either:

--- a/dsctriage/dsctriage.py
+++ b/dsctriage/dsctriage.py
@@ -120,14 +120,15 @@ def parse_dates(start=None, end=None):
     return start, end
 
 
-def show_header(category_name, pretty_start_date, pretty_end_date):
+def show_header(category_name, pretty_start_date, pretty_end_date, site=None):
     """Show a dynamic header explaining results."""
     date_range_info = ('on ' + str(pretty_start_date)) \
         if pretty_start_date == pretty_end_date \
         else ('between ' + str(pretty_start_date) + ' and ' + str(pretty_end_date) + ' inclusive')
 
     logging.info('Discourse Comment Triage Helper')
-    logging.info('Showing comments belonging to the %s category, updated %s', str(category_name), date_range_info)
+    logging.info('Showing comments belonging to the %s category%s, updated %s', str(category_name),
+                 f" on {site}" if site is not None else "", date_range_info)
 
 
 def create_hyperlink(url, text):
@@ -390,7 +391,7 @@ def main(category_name, date_range=None, debug=False, progress_bar=False, open_b
     pretty_end = end.strftime('%Y-%m-%d (%A)')
     end += timedelta(days=1)
 
-    show_header(category_name, pretty_start, pretty_end)
+    show_header(category_name, pretty_start, pretty_end, site)
 
     dscfinder.add_topics_to_category(category, start, site)
     fill_topics(category.get_topics(), progress_bar, site)
@@ -416,6 +417,8 @@ def launch():
                         help='open comments in web browser')
     parser.add_argument('--fullurls', default=False, action='store_true',
                         help='show full URLs instead of shortcuts')
+    parser.add_argument('-s', '--site', dest='site_url', default=None,
+                        help='The discourse website or server to find comments from')
     parser.add_argument('-c', '--category', dest='category_name', default='Server',
                         help='The discourse category to find comments from')
     parser.add_argument('-b', '--backlog', dest='backlog_post_id',
@@ -426,6 +429,6 @@ def launch():
                   'end': args.end_date}
 
     if args.backlog_post_id:
-        print_post_in_backlog_format(args.backlog_post_id)
+        print_post_in_backlog_format(args.backlog_post_id, args.site_url)
     else:
-        main(args.category_name, date_range, args.debug, True, args.open, not args.fullurls)
+        main(args.category_name, date_range, args.debug, True, args.open, not args.fullurls, args.site_url)

--- a/dsctriage/dsctriage.py
+++ b/dsctriage/dsctriage.py
@@ -294,20 +294,27 @@ def get_post_with_metadata_from_post_id(post_id, post_metadata_list):
     return None
 
 
+def get_metadata_for_posts_of_topic(topic, start, end, site=None):
+    """Return list of posts in topic + additional metadata about their relevance and if there were relevant posts."""
+    post_metadata_list = []
+    topic_is_relevant = False
+
+    for i, post in enumerate(topic.get_posts()):
+        new_meta_post = create_post_with_metadata(post, start, end, dscfinder.get_post_url(topic, i, site))
+        post_metadata_list.append(new_meta_post)
+
+        if new_meta_post.status != PostStatus.UNCHANGED:
+            topic_is_relevant = True
+
+    return post_metadata_list, topic_is_relevant
+
+
 def print_comments(category, start, end, open_in_browser=False, shorten_links=True, site=None):
     """Display relevant posts in a readable format."""
     initial_browser_open = True
 
     for topic in category.get_topics():
-        print_topic = False
-        post_metadata_list = []
-        # Get relevant posts for a topic and add metadata
-        for i, post in enumerate(topic.get_posts()):
-            new_meta_post = create_post_with_metadata(post, start, end, dscfinder.get_post_url(topic, i, site))
-            post_metadata_list.append(new_meta_post)
-
-            if new_meta_post.status != PostStatus.UNCHANGED:
-                print_topic = True
+        post_metadata_list, print_topic = get_metadata_for_posts_of_topic(topic, start, end, site)
 
         # organize reply structure, remove replies from list, and open in browser if requested
         final_meta_post_list = []

--- a/dsctriage/dsctriage.py
+++ b/dsctriage/dsctriage.py
@@ -352,6 +352,18 @@ def print_post_in_backlog_format(post_id, site=None):
                              dscfinder.get_post_url_without_topic(backlog_post, site), False)
 
 
+def fill_topics(topics, progress_bar, site=None):
+    """Download posts related to a list of topics and display progress if desired and available."""
+    if progress_bar and alive_bar is not None:
+        with alive_bar(len(topics)) as bar_view:
+            for topic in topics:
+                dscfinder.add_posts_to_topic(topic, site)
+                bar_view()
+    else:
+        for topic in topics:
+            dscfinder.add_posts_to_topic(topic, site)
+
+
 def main(category_name, date_range=None, debug=False, progress_bar=False, open_browser=False, shorten_links=True,
          site=None, log_stream=sys.stdout):
     """Download contents of a given category, find relevant posts, print them to console."""
@@ -374,16 +386,7 @@ def main(category_name, date_range=None, debug=False, progress_bar=False, open_b
     show_header(category_name, pretty_start, pretty_end)
 
     dscfinder.add_topics_to_category(category, start, site)
-
-    topics = category.get_topics()
-    if progress_bar and alive_bar is not None:
-        with alive_bar(len(topics)) as bar_view:
-            for topic in topics:
-                dscfinder.add_posts_to_topic(topic, site)
-                bar_view()
-    else:
-        for topic in topics:
-            dscfinder.add_posts_to_topic(topic, site)
+    fill_topics(category.get_topics(), progress_bar, site)
 
     print_comments(category, start, end, open_browser, shorten_links, site)
 

--- a/dsctriage/dsctriage_test.py
+++ b/dsctriage/dsctriage_test.py
@@ -3,7 +3,7 @@ import datetime
 import json
 import pytest
 
-from dsctriage import DiscoursePost, DiscourseTopic, DiscourseCategory
+from dsctriage import DiscoursePost, DiscourseTopic, DiscourseCategory, dscfinder
 
 
 # pylint: disable=too-many-arguments
@@ -156,3 +156,14 @@ def test_add_topics_to_category():
     assert "not a DiscourseTopic" in str(err_2.value)
 
     assert len(category.get_topics()) == 2
+
+
+@pytest.mark.parametrize('url_out, template, id_var, site', [
+    ("https://discourse.ubuntu.com/posts/12453.json", dscfinder.POST_JSON_URL, 12453, None),
+    ("http://test/posts/1111.json", dscfinder.POST_JSON_URL, "1111", "http://test"),
+    ("https://discourse.ubuntu.com/posts/1/revisions/latest.json", dscfinder.POST_LATEST_EDIT_JSON_URL, 1, None),
+    ("https://discourse.ubuntu.com/categories.json", dscfinder.CATEGORY_LIST_JSON_URL, None, None)
+])
+def test_dscfinder_create_url(url_out, template, id_var, site):
+    """Test that dscfinder creates urls correctly."""
+    assert url_out == dscfinder.create_url(template, id_var, site)


### PR DESCRIPTION
Users can now specify a different discourse server name for triage. Closes #2 