### PR TITLE
[fix] use pytest entry point not py.test

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -21,7 +21,7 @@ deps =
     pytest
     pytest-cov
 commands =
-    py.test --cov dsctriage dsctriage
+    pytest --cov dsctriage dsctriage
 
 [flake8]
 max-line-length = 120


### PR DESCRIPTION
As per https://docs.pytest.org/en/stable/changelog.html#release-3-0-0 , since 2016 the pytest project prefers `pytest` over `py.test`