### PR TITLE
Re-organise tox targets

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,28 +1,29 @@
 [tox]
-envlist = flake8, black, pylint, pytest
-recreate = true
+envlist = format, lint, test
 skipsdist = true
 
-[testenv:flake8]
-deps =
-    flake8
-    flake8-docstrings
-commands = flake8 dsctriage setup.py
-
-[testenv:black]
+[testenv:lint]
+description=Check code for lint issues
 deps =
     black
-commands =
-    black --check --line-length=120 dsctriage setup.py
-
-[testenv:pylint]
-deps =
+    flake8
+    flake8-docstrings
     pylint
     pytest
 commands =
+    flake8 dsctriage setup.py
+    black --check --line-length=120 dsctriage setup.py
     pylint --max-line-length=120 dsctriage setup.py
 
-[testenv:pytest]
+[testenv:format]
+description=Format the code using Black
+deps =
+    black
+commands =
+    black --line-length=120 dsctriage setup.py
+
+[testenv:test]
+description=Run the unit tests, with coverage
 deps =
     pytest
     pytest-cov


### PR DESCRIPTION
`format`, `lint`, `test` instead of `flake8`, `black`, `pylint`, `pytest`