### PR TITLE
Configuration management

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## Unreleased
+
+### Added
+
+* Configuration management through `dsctriage.conf`
+* The `--set-defaults` argument
+
 ## 1.4.1
 
 Released on March 10, 2023

--- a/README.md
+++ b/README.md
@@ -102,3 +102,10 @@ with the ID 14159:
 or:
 
     dsctriage --backlog 14159
+
+### Set default category and server
+To update the Discourse server and category used by default, add the `--set-defaults` argument during a dsctriage run
+against them. Future runs will no longer need them to be specified each time. For example, the following will run
+dsctriage and set the default category to `announcements` in the Discourse meta site: 
+
+    dsctriage -s https://meta.discourse.org -c announcements --set-defaults

--- a/README.md
+++ b/README.md
@@ -109,3 +109,30 @@ against them. Future runs will no longer need them to be specified each time. Fo
 dsctriage and set the default category to `announcements` in the Discourse meta site: 
 
     dsctriage -s https://meta.discourse.org -c announcements --set-defaults
+
+## Configuration
+Alongside the `--set-defaults` argument shown above, Discourse Triage can be configured the `dsctriage.conf` file. This
+can be found in `/snap/dsctriage/etc/` when using the snap, or can be added to `/etc` when running with `python3 -m`.
+
+### Usage
+The `dsctriage.conf` file works as a standard config file, where options are set in the `[dsctriage]` section using a
+`=`. Here is an example of a valid `dsctriage.conf`:
+
+    [dsctriage]
+    category = doc
+    site = https://forum.snapcraft.io
+    progress_bar = True
+    shorten_links = True
+
+### Options
+The following options can be modified in the config file:
+
+* `category`
+    - The Discourse category to look at, initially defaults to `Server`
+* `site`
+    - The Discourse site URL to look at, initially defaults to `https://discourse.ubuntu.com`
+* `progress_bar`
+    - Whether to show the progress bar when running dsctriage, defaults to `True`
+* `shorten_links`
+    - Whether to show links as hyperlinks in the post number, or print them fully. Defaults to `True`, making them
+    hyperlinks.

--- a/dsctriage/dscconfig.py
+++ b/dsctriage/dscconfig.py
@@ -1,0 +1,70 @@
+"""dsctriage configuration manager."""
+import configparser
+
+default_config = {
+    "dsctriage": {
+        "category": "Server",
+        "site": "https://discourse.ubuntu.com",
+        "progress_bar": True,
+        "shorten_links": True,
+    }
+}
+
+
+class Config:
+    """Class for interacting with a dsctriage config file."""
+
+    def __init__(self, config_filename="/etc/dsctriage.conf"):
+        """Set configuration to default then update config from aa given file if available."""
+        self._config = configparser.ConfigParser()
+        self._config.read_dict(default_config)
+
+        try:
+            self._config.read(config_filename)
+        except FileNotFoundError:
+            pass
+
+    def save(self, config_filename="/etc/dsctriage.conf"):
+        """Save configuration to a file."""
+        with open(config_filename, "w", encoding="utf-8") as config_file:
+            self._config.write(config_file)
+
+    @property
+    def category(self):
+        """Get the value of the default Discourse category to gather data from."""
+        return self._config.get("dsctriage", "category")
+
+    @category.setter
+    def category(self, value):
+        """Set the default Discourse category to gather data from."""
+        self._config.set("dsctriage", "category", value)
+
+    @property
+    def site(self):
+        """Get the value of the default Discourse site URL to gather data from."""
+        return self._config.get("dsctriage", "site")
+
+    @site.setter
+    def site(self, value):
+        """Set the default Discourse site URL to gather data from."""
+        self._config.set("dsctriage", "site", value)
+
+    @property
+    def progress_bar(self):
+        """Get the configuration for whether to show the progress bar during download."""
+        return self._config.getboolean("dsctriage", "progress_bar")
+
+    @progress_bar.setter
+    def progress_bar(self, value):
+        """Set the configuration for whether to show the progress bar during download."""
+        self._config.set("dsctriage", "progress_bar", value)
+
+    @property
+    def shorten_links(self):
+        """Get the configuration for whether to use hyperlinks or full links in the output."""
+        return self._config.getboolean("dsctriage", "shorten_links")
+
+    @shorten_links.setter
+    def shorten_links(self, value):
+        """Set the configuration for whether to use hyperlinks or full links in the output."""
+        self._config.set("dsctriage", "shorten_links", value)

--- a/dsctriage/dsctriage.py
+++ b/dsctriage/dsctriage.py
@@ -10,6 +10,7 @@ import re
 import logging
 import webbrowser
 from . import dscfinder
+from .dscconfig import Config
 
 try:
     from alive_progress import alive_bar
@@ -447,7 +448,9 @@ def main(
 
 
 def launch():
-    """Launch discourse-triage via the command line with given arguments."""
+    """Launch discourse-triage via the command line with given arguments and active configuration."""
+    config = Config()
+
     parser = argparse.ArgumentParser()
     parser.add_argument(
         "start_date",
@@ -470,7 +473,7 @@ def launch():
     )
     parser.add_argument(
         "--fullurls",
-        default=False,
+        default=not config.shorten_links,
         action="store_true",
         help="show full URLs instead of shortcuts",
     )
@@ -478,14 +481,14 @@ def launch():
         "-s",
         "--site",
         dest="site_url",
-        default=None,
+        default=config.site,
         help="The discourse website or server to find comments from",
     )
     parser.add_argument(
         "-c",
         "--category",
         dest="category_name",
-        default="Server",
+        default=config.category,
         help="The discourse category to find comments from",
     )
     parser.add_argument(
@@ -505,7 +508,7 @@ def launch():
             args.category_name,
             date_range,
             args.debug,
-            True,
+            config.progress_bar,
             args.open,
             not args.fullurls,
             args.site_url,

--- a/dsctriage/dsctriage.py
+++ b/dsctriage/dsctriage.py
@@ -497,7 +497,18 @@ def launch():
         dest="backlog_post_id",
         help="Display a post of a given ID in a standard backlog format",
     )
+    parser.add_argument(
+        "--set-defaults",
+        dest="set_defaults",
+        action="store_true",
+        help="Update the default configuration to use the provided site and category",
+    )
     args = parser.parse_args()
+
+    if args.set_defaults:
+        config.site = args.site_url
+        config.category = args.category_name
+        config.save()
 
     date_range = {"start": args.start_date, "end": args.end_date}
 

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -22,3 +22,7 @@ parts:
     plugin: python
     source: https://github.com/lvoytek/discourse-triage
     source-type: git
+
+layout:
+  /etc/dsctriage.conf:
+    bind-file: $SNAP_DATA/etc/dsctriage.conf


### PR DESCRIPTION
Add the ability to configure defaults for dsctriage with `dsctriage.conf` and add the `--set-defaults` argument for cli updates to server and category. Closes #13 