### PR TITLE
Propagate user-specified site when generating username URL 

### DIFF
--- a/dsctriage/dscfinder.py
+++ b/dsctriage/dscfinder.py
@@ -299,7 +299,7 @@ def create_editor_name_str(post, site=None):
             if "username" in json_output:
                 author_name = json_output["username"]
 
-                user_url = create_url(USER_JSON_URL, json_output["username"])
+                user_url = create_url(USER_JSON_URL, json_output["username"], site)
             with request.urlopen(user_url) as user_url_data:
                 user_json_output = json.loads(user_url_data.read().decode())
 


### PR DESCRIPTION
## Issue

When a `--site` other than the default `discourse.ubuntu.com` is specified, the script continues to construct user URLS using `discourse.ubuntu.com`.

This causes the HTTP response to the user URL to fail if the user does not exist in the ubuntu instance.

Example command & output snippet:
```bash
dsctriage --site https://discourse.charmhub.io --category charm --debug
``` 
```
...
Extracting editor username from latest edit at https://discourse.charmhub.io/posts/30206/revisions/latest.json
Failed to get user from URL https://discourse.ubuntu.com/u/v-izmalkov.json
*Charmed Apache Spark Doc… [v-izmalkov, 2024-11-26] 
...
```

This is because the `create_url()` function resorts to the default site when it does not receive a `site` input variable.

## Solution
I believe this can be easily solved by just propagating the `site` variable inside the `create_editor_name_str()` function when creating the `user_url` for the request.